### PR TITLE
Include Ruby case statements in block scope

### DIFF
--- a/bh_core.sublime-settings
+++ b/bh_core.sublime-settings
@@ -217,7 +217,7 @@
         // Ruby conditional statements
         {
             "name": "ruby",
-            "open": "(^\\s*\\b(?:if|until|unless|while|begin|class|module|def\\b\\s*[a-zA-Z_]+)|do)\\b",
+            "open": "(^\\s*\\b(?:if|case|until|unless|while|begin|class|module|def\\b\\s*[a-zA-Z_]+)|do)\\b",
             "close": "\\b(end)\\b",
             "style": "default",
             "scope_exclude": ["string", "comment"],


### PR DESCRIPTION
Include Ruby `case` statements into block highlighting.
