### PR TITLE
Include Rails as Ruby language

### DIFF
--- a/bh_core.sublime-settings
+++ b/bh_core.sublime-settings
@@ -223,7 +223,7 @@
             "scope_exclude": ["string", "comment"],
             "plugin_library": "bh_modules.rubykeywords",
             "language_filter": "whitelist",
-            "language_list": ["Ruby"],
+            "language_list": ["Ruby", "Ruby on Rails", "HTML (Rails)"],
             "enabled": true
         },
         // C/C++ compile switches


### PR DESCRIPTION
Include languages `Ruby on Rails` and `HTML (Rails)` in Ruby block scoping
