### PR TITLE
Add conditional statement support for Erlang

### DIFF
--- a/bh_core.sublime-settings
+++ b/bh_core.sublime-settings
@@ -236,6 +236,17 @@
             "language_filter": "whitelist",
             "language_list": ["C++", "C", "Objective-C"],
             "enabled": true
+        },
+        // Erlang conditional statements
+        {
+            "name": "erlang",
+            "open": "\\s*(\\b(?:if|case|begin|try|fun|receive)\\b)",
+            "close": "\\b(end)\\b",
+            "style": "default",
+            "scope_exclude": ["string", "comment"],
+            "language_filter": "whitelist",
+            "language_list": ["Erlang", "HTML (Erlang)"],
+            "enabled": true
         }
     ],
 


### PR DESCRIPTION
Support for Erlang conditional statements.

I was trying to match the regular expression `fun\\.*\\->` (or similar) to match start tags of the form `fun() ->` or `fun  (A, B, C) ->` but didn't succeed. Perhaps someone has a better idea of how to match this. The start expression `fun\\(*` matches the case `fun()` but not `fun(_)` for example.
