### PR TITLE
Fixed missing word boundary character in ruby conditional open statements

### DIFF
--- a/bh_core.sublime-settings
+++ b/bh_core.sublime-settings
@@ -241,7 +241,7 @@
         // Ruby conditional statements
         {
             "name": "ruby",
-            "open": "(^\\s*\\b(?:if|case|until|unless|while|begin|class|module|def\\b\\s*[a-zA-Z_\\d]+)|do)\\b",
+            "open": "(^\\s*\\b(?:if|case|until|unless|while|begin|class|module|def\\b\\s*[a-zA-Z_\\d]+)|\\bdo)\\b",
             "close": "\\b(end)\\b",
             "style": "default",
             "scope_exclude": ["string", "comment"],


### PR DESCRIPTION
Behaviour:
When using variable names ending in "do", bracket highlighting is thrown off, assuming the do in the variable name is the start of a block

Example:

``` ruby
def initialize
  EM.run do
    @collection.each do |member|
      @todo << member
    end
    start_processing
  end
end
```

Expected Behaviour:
Bracket Highlighting allows for variables ending in "do"
