### PR TITLE
Fix bug in BhCore.match

### DIFF
--- a/bh_core.py
+++ b/bh_core.py
@@ -808,10 +808,11 @@ class BhCore(object):
         Preform matching brackets surround the selection(s)
         """
 
-        view.settings().set("BracketHighlighterBusy", True)
-
         if view == None:
             return
+
+        view.settings().set("BracketHighlighterBusy", True)
+
         if not GLOBAL_ENABLE:
             for region_key in view.settings().get("bh_regions", []):
                 view.erase_regions(region_key)


### PR DESCRIPTION
There seemed to be a little bug in `BhCore.match` in the [last commit](https://github.com/facelessuser/BracketHighlighter/commit/fb942d49ba5ce335fb3d43e367b406dac65c93d4#L0R811) which made the plugin stop.
