### PR TITLE
Recognise Handlebars templates as HTML

### DIFF
--- a/bh_core.sublime-settings
+++ b/bh_core.sublime-settings
@@ -209,7 +209,7 @@
             "style": "tag",
             "scope_exclude": ["string", "comment"],
             "language_filter": "whitelist",
-            "language_list": ["HTML", "HTML 5", "XML", "PHP"],
+            "language_list": ["HTML", "HTML 5", "XML", "PHP", "Handlebars"],
             "plugin_library": "bh_modules.tags",
             "find_in_sub_search": "only",
             "enabled": false
@@ -246,7 +246,7 @@
             "style": "angle",
             "scope_exclude": ["string", "comment", "keyword.operator", "source.ruby.rails.embedded.html", "source.ruby.embedded.html"],
             "language_filter": "whitelist",
-            "language_list": ["HTML", "HTML 5", "XML", "PHP", "HTML (Rails)", "HTML (Jinja Templates)", "HTML (Twig)", "HTML+CFML", "ColdFusion", "ColdFusionCFC", "laravel-blade"],
+            "language_list": ["HTML", "HTML 5", "XML", "PHP", "HTML (Rails)", "HTML (Jinja Templates)", "HTML (Twig)", "HTML+CFML", "ColdFusion", "ColdFusionCFC", "laravel-blade", "Handlebars"],
             "plugin_library": "bh_modules.tags",
             "enabled": true
         },
@@ -417,7 +417,7 @@
     // Determine which style of tag-matching to use in which syntax
     "tag_mode": {
         "xhtml": ["XML"],
-        "html": ["HTML", "HTML 5", "PHP", "HTML (Jinja Templates)", "HTML (Rails)", "HTML (Twig)", "laravel-blade"],
+        "html": ["HTML", "HTML 5", "PHP", "HTML (Jinja Templates)", "HTML (Rails)", "HTML (Twig)", "laravel-blade", "Handlebars"],
         "cfml": ["HTML+CFML", "ColdFusion", "ColdFusionCFC"]
     }
 }


### PR DESCRIPTION
Allow BracketHighlighter to recognise Handlebars templates as HTML so that HTML tags work. Closes #162
