### PR TITLE
fix bash, add fish shell

### DIFF
--- a/bh_core.sublime-settings
+++ b/bh_core.sublime-settings
@@ -322,7 +322,7 @@
         {
             "name": "bash",
             "open": "(?:(?<!\\\\\\n)(?:;|^|&|\\|)\\s*)\\b(if|case|while|select|until|for)\\s",
-            "close": "(?:(?<!\\\\\\n)(?:;|^)\\s*)\\b(fi|esac|done)(?:;|\\s|$)",
+            "close": "(?:(?<!\\\\\\n)(?:;|^)\\s*)\\b(fi|esac|done)(?=;|\\s|$)",
             "style": "default",
             "scope_exclude": ["string", "comment"],
             "plugin_library": "bh_modules.bashsupport",
@@ -334,7 +334,7 @@
         {
             "name": "fish",
             "open": "(?:(?<!\\\\\\n)(?:;|^|&|\\||and|or|not)\\s*)\\b(begin|if|while|for|switch|function)(?:;|\\s)",
-            "close": "(?:(?<!\\\\\\n)(?:;|^)\\s*)\\b(end)(?:;|\\s|$)",
+            "close": "(?:(?<!\\\\\\n)(?:;|^)\\s*)\\b(end)(?=;|\\s|$)",
             "style": "default",
             "scope_exclude": ["string", "comment"],
             "language_filter": "whitelist",


### PR DESCRIPTION
# Bash
- allows semicolon after fi/done/esac, as in:

```
if foo; then
  bar
fi; <--- here
```
- allows `&`, `&&`, `|`, `||` in front of opening keywords
# Fish shell

basic support for [fish-shell](/fish-shell/fish-shell/)
- Adds the opening keywords `if`, `while`, `for`, `switch`, `function` and `begin`.
  They must be   prefixed by either
  - the beginning of a line
  - a semicolon `;`
  - `and`, `or` or `not`
  
  and optional whitespace.
  They must also be suffixed by either a semicolon or whitespace.
- Aalso adds the closing keyword `end`, following the same criteria as
  above, but excluding '`and`, `or` and `not`
