### PR TITLE
Don't match variables/symbols as the `end` keyword in Ruby

### DIFF
--- a/bh_core.sublime-settings
+++ b/bh_core.sublime-settings
@@ -274,7 +274,7 @@
         {
             "name": "ruby_embedded_html",
             "open": "((?:(?<=<%)|(?<=^)|(?<==))\\s*\\b(?:if|begin|case)\\b|(?:(?<=<%)|(?<=^))\\s*\\b(?:for|until|unless|while|class|module|def\\b[\\p{Ll}\\p{Lu}]*)|\\bdo)\\b",
-            "close": "[\\s;](end)\\b(?:(?!:))",
+            "close": "(?<=[\\s;])(end)\\b(?!:)",
             "style": "default",
             "scope_exclude": ["text.html", "source", "comment", "string"],
             "scope_exclude_exceptions": ["source.ruby.rails.embedded.html", "source.ruby.embedded.html"],
@@ -287,7 +287,7 @@
         {
             "name": "ruby",
             "open": "((?:(?<=^)|(?<==))\\s*\\b(?:if|begin|case)\\b|^\\s*\\b(?:for|until|unless|while|class|module|def\\b[\\p{Ll}\\p{Lu}]*)|\\bdo)\\b",
-            "close": "[\\s;](end)\\b(?:(?!:))",
+            "close": "(?<=[\\s;])(end)\\b(?!:)",
             "style": "default",
             "scope_exclude": ["string", "comment"],
             "plugin_library": "bh_modules.rubykeywords",


### PR DESCRIPTION
To avoid matching variables and symbols named `end` as the keyword for a block, the regular expression was updated to:
- not match if there is a colon after `end` (then `end` is a symbol key in a hash)
- match whitespace before `end` instead of word boundary (to avoid matching `self.end` and the like)
- match semicolon before `end` in addition to whitespace (because `do; ...;end` is a valid line, even if formatted poorly)

This fixes #193 and some other edge cases.
