### PR TITLE
Disable PHP angle bracket in PHP files, keep in HTML

### DIFF
--- a/bh_core.sublime-settings
+++ b/bh_core.sublime-settings
@@ -244,7 +244,7 @@
             "style": "angle",
             "scope_exclude": ["string", "comment", "keyword.operator"],
             "language_filter": "whitelist",
-            "language_list": ["HTML", "HTML 5", "PHP"],
+            "language_list": ["HTML", "HTML 5"],
             "enabled": true
         },
         // Angle
@@ -451,7 +451,7 @@
     // Determine which style of tag-matching to use in which syntax
     "tag_mode": {
         "xhtml": ["XML"],
-        "html": ["HTML", "HTML 5", "PHP", "HTML (Jinja Templates)", "HTML (Rails)", "HTML (Twig)", "laravel-blade", "Handlebars", "AngularJS"],
+        "html": ["HTML", "HTML 5", "HTML (Jinja Templates)", "HTML (Rails)", "HTML (Twig)", "laravel-blade", "Handlebars", "AngularJS"],
         "cfml": ["HTML+CFML", "ColdFusion", "ColdFusionCFC"]
     }
 }


### PR DESCRIPTION
It is a widely accepted practice to not put the closing PHP bracket in PHP files. See the popular [PSR-2 guide](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md#22-files) for an example.

With `show_unmatched` this results in a permanent useless warning:
![1](https://cloud.githubusercontent.com/assets/113721/5356494/cd10fbd4-7fa5-11e4-8de8-669ffbd8dabe.png)

In HTML template files the bracket is still useful, as there developers open and close PHP brackets all the time.
