### PR TITLE
Compatibility with Vintageous

### DIFF
--- a/bh_core.py
+++ b/bh_core.py
@@ -786,6 +786,20 @@ class BhListenerCommand(sublime_plugin.EventListener):
             BhEventMgr.modified = True
             BhEventMgr.time = now
 
+    def on_window_command(self, view, command_name, args):
+        """
+        Highlight brackets when Vintageous sends a key.
+        """
+        if command_name != "press_key":
+            return
+        now = time()
+        if now - BhEventMgr.time > BhEventMgr.wait_time:
+            sublime.set_timeout(bh_run, 0)
+        else:
+            BhEventMgr.modified = True
+            BhEventMgr.time = now
+
+
     def ignore_event(self, view):
         """
         Ignore request to highlight if the view is a widget,


### PR DESCRIPTION
Fixes #202 

This is the quickest fix I could find. I have never wrote python before but I just copied from above listeners and used the sublime api to find where the event was firing from.

```python
if command_name != "pres_key":
```
Could be changed to be stricter by also checking against the args, here is what the args for Vintageous look like `{'key': 'j'}` I would implement it myself but I have no experience with python. If you need any more information please let me know and I would be happy to help, this is one of my must have plugins.