### PR TITLE
Fix ruby "do" block highlighting

### DIFF
--- a/bh_core.sublime-settings
+++ b/bh_core.sublime-settings
@@ -290,7 +290,7 @@
         // Ruby embedded HTML
         {
             "name": "ruby_embedded_html",
-            "open": "((?:(?<=<%)|(?<=^)|(?<==))\\s*\\b(?:if|begin|case)\\b|(?:(?<=<%)|(?<=^))\\s*\\b(?:for|until|unless|while|class|module|def\\b[\\p{Ll}\\p{Lu}]*)|\\bdo)\\b",
+            "open": "((?:(?<=<%)|(?<=^)|(?<==))\\s*\\b(?:if|begin|case)\\b(?!:)|(?:(?<=<%)|(?<=^))\\s*\\b(?:for|until|unless|while|class|module|def\\b[\\p{Ll}\\p{Lu}]*)\\b|(?<!:)\\bdo\\b(?!:))",
             "close": "(?<=[\\s;])(end)\\b(?!:)",
             "style": "default",
             "scope_exclude": ["text.html", "source", "comment", "string"],
@@ -306,7 +306,7 @@
         // Ruby conditional statements
         {
             "name": "ruby",
-            "open": "((?:(?<=^)|(?<==))\\s*\\b(?:if|begin|case)\\b|^\\s*\\b(?:for|until|unless|while|class|module|def\\b[\\p{Ll}\\p{Lu}]*)|\\bdo)\\b",
+            "open": "((?:(?<=^)|(?<==))\\s*\\b(?:if|begin|case)\\b(?!:)|^\\s*\\b(?:for|until|unless|while|class|module|def\\b[\\p{Ll}\\p{Lu}]*)\\b|(?<!:)\\bdo\\b(?!:))",
             "close": "(?<=[\\s;])(end)\\b(?!:)",
             "style": "default",
             "scope_exclude": ["string", "comment"],


### PR DESCRIPTION
Hey,

I have some issues with "do - end" ruby blocks.
When I use `do` as a symbol for describing state machine by using it's DSL, BH highlights it:

```ruby
state_machine :moderation_state do
  after_transition on: :approve, do: :handle_approve
  ...
end
```

I would suggest to add additional check to ensure that this reserved words used not as symbols.
With this changes the following code should work properly:

```ruby
state_machine :moderation_state do
  foo :do => :bar
  foo do: :bar

  foo :begin => :bar
  foo begin: :bar

  foo :while => :bar
  foo whiel: :bar
end
```

Thanks!