### PR TITLE
Allow matching with Better RSpec package

### DIFF
--- a/bh_core.sublime-settings
+++ b/bh_core.sublime-settings
@@ -155,7 +155,7 @@
             "style": "regex",
             "scopes": ["string"],
             "language_filter": "whitelist",
-            "language_list": ["Ruby", "RSpec"],
+            "language_list": ["Ruby", "RSpec", "Better RSpec"],
             "sub_bracket_search": "true",
             "enabled": true
         },
@@ -318,7 +318,7 @@
             "scope_exclude": ["string", "comment"],
             "plugin_library": "bh_modules.rubykeywords",
             "language_filter": "whitelist",
-            "language_list": ["Ruby", "RSpec", "Ruby on Rails"],
+            "language_list": ["Ruby", "RSpec", "Better RSpec", "Ruby on Rails"],
             "enabled": true
         },
         // C/C++ compile switches


### PR DESCRIPTION
This will allow bracket matching to occur when the syntax is set to "Better RSpec" from the package: https://github.com/fnando/better-rspec-for-sublime-text