### PR TITLE
Add bh_tag settings to Sublime settings menu

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -234,6 +234,17 @@
                             { "caption": "-" },
                             {
                                 "command": "open_file",
+                                "args": {"file": "${packages}/BracketHighlighter/bh_tag.sublime-settings"},
+                                "caption": "Tag Settings – Default"
+                            },
+                            {
+                                "command": "open_file",
+                                "args": {"file": "${packages}/User/bh_tag.sublime-settings"},
+                                "caption": "Tag Settings – User"
+                            },
+                            { "caption": "-" },
+                            {
+                                "command": "open_file",
                                 "args": {"file": "${packages}/BracketHighlighter/bh_wrapping.sublime-settings"},
                                 "caption": "Wrap Settings – Default"
                             },


### PR DESCRIPTION
I needed to access `bh_tag.sublime-settings` to add a language to the `tag_mode` list so it would highlight properly.  It would be great if we could access this settings file from the menu, instead of having to find and create it manually.