### PR TITLE
Add support for HTML (Django) by default

### DIFF
--- a/bh_core.sublime-settings
+++ b/bh_core.sublime-settings
@@ -270,6 +270,7 @@
                 "XML",
                 "PHP",
                 "HTML (Rails)",
+                "HTML (Django)",
                 "HTML (Jinja Templates)",
                 "HTML (Twig)",
                 "HTML+CFML",

--- a/bh_tag.sublime-settings
+++ b/bh_tag.sublime-settings
@@ -14,6 +14,7 @@
             "PHP",
             "HTML (Jinja Templates)",
             "HTML (Rails)",
+            "HTML (Django)",
             "HTML (Twig)",
             "laravel-blade",
             "Handlebars",

--- a/docs/customize.md
+++ b/docs/customize.md
@@ -167,7 +167,7 @@ Disables gutter icons when doing multiple selections.
 ```
 
 ## Tag Plugin Settings
-Tag settings found in `bh_core.sublime-settings`.
+Tag settings found in `bh_tag.sublime-settings`.
 
 ### tag_style
 Sets the highlight style for the tag plugin.  The string value should correspond to a style entry in `bracket_styles`.  See [Configuring Highlight Style](#configuring-highlight-style) for more info.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -14,8 +14,9 @@ BH supports a variety of brackets out of the box; here are some examples:
 - curly
 - angle
 - single and double quotes
-- python single and double quotes (Unicode and raw)
-- python triple single and double quotes (Unicode and raw)
+- Python single and double quotes (Unicode and raw)
+- Python triple single and double quotes (Unicode and raw)
+- Django Python templates with mixed HTML, CSS, and JS
 - JavaScript regex
 - Perl regex
 - Ruby regex
@@ -62,7 +63,7 @@ Folds the content of the current surrounding brackets.
 Swaps the quote style of surrounding quotes from double to single or vice versa.  It also handles escaping and un-escaping of sub quotes.
 
 ### Tag Plugin
-Provides extra logic to target and highlight XML/HTML tags.
+Provides extra logic to target and highlight XML/HTML tags.  To use BracketHighlighter's built-in HTML highlighting in your HTML-like template language of choice, add it to the list in `bh_tag.sublime_settings`.
 
 ### Tag Attribute Select Plugin
 Cycles through selecting tag attributes.


### PR DESCRIPTION
All it takes to enable BracketHighlighter's awesome HTML tag support in Django templates is adding these two lines.  Now when people install BH after Djaneiro or another package that adds embedded Django HTML support it'll "just work".