### PR TITLE
Experimental block cursor mode

### DIFF
--- a/.sublimelinterrc
+++ b/.sublimelinterrc
@@ -2,11 +2,11 @@
     "@python": 3,
     "linters": {
         "flake8": {
-            "ignore": "",
+            "ignore": "D202,D203",
             "max-line-length": 120
         },
         "pep257": {
-            "ignore": "D202"
+            "ignore": "D202,D203"
         }
     }
 }

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -42,6 +42,7 @@
         "args":
         {
             "no_outside_adj": null,
+            "no_block_mode": null,
             "lines" : true,
             "plugin":
             {
@@ -58,6 +59,7 @@
         "args":
         {
             "no_outside_adj": null,
+            "no_block_mode": null,
             "lines" : true,
             "plugin":
             {

--- a/Example.sublime-keymap
+++ b/Example.sublime-keymap
@@ -20,6 +20,7 @@
         "args":
         {
             "no_outside_adj": null,
+            "no_block_mode": null,
             "lines" : true,
             "plugin":
             {
@@ -36,6 +37,7 @@
         "args":
         {
             "no_outside_adj": null,
+            "no_block_mode": null,
             "lines" : true,
             "plugin":
             {

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -38,6 +38,7 @@
                                 "args":
                                 {
                                     "no_outside_adj": null,
+                                    "no_block_mode": null,
                                     "lines" : true,
                                     "plugin":
                                     {
@@ -54,6 +55,7 @@
                                 "args":
                                 {
                                     "no_outside_adj": null,
+                                    "no_block_mode": null,
                                     "lines" : true,
                                     "plugin":
                                     {

--- a/bh_core.py
+++ b/bh_core.py
@@ -86,7 +86,8 @@ class BhCore(object):
             self.settings.get("brackets", []) + self.settings.get("user_brackets", []),
             self.settings.get("scope_brackets", []) + self.settings.get("user_scope_brackets", []),
             str(self.settings.get('bracket_string_escape_mode', "string")),
-            False if no_outside_adj else self.settings.get("bracket_outside_adjacent", False)
+            False if no_outside_adj else self.settings.get("bracket_outside_adjacent", False),
+            self.settings.get('block_cursor_mode', False)
         )
 
         # Init selection params
@@ -519,7 +520,7 @@ class BhCore(object):
 
         # Cannot be inside a bracket pair if cursor is at zero
         if center == 0:
-            if not self.rules.outside_adj:
+            if not self.rules.outside_adj and not self.rules.block_cursor:
                 return left, right, selected_scope, False
 
         for s in self.rules.scopes:
@@ -564,7 +565,13 @@ class BhCore(object):
             left, right = partial_find[0], partial_find[1]
 
         # Make sure cursor in highlighted sub group
-        if self.rules.outside_adj:
+        if self.rules.block_cursor:
+            if (
+                (left and center < left.begin and adjusted_center <= left.begin) or
+                (right and center >= right.end and adjusted_center >= right.end)
+            ):
+                left, right = None, None
+        elif self.rules.outside_adj:
             if (
                 (left and center <= left.begin and adjusted_center <= left.begin) or
                 (right and center >= right.end and adjusted_center >= right.end)

--- a/bh_core.sublime-settings
+++ b/bh_core.sublime-settings
@@ -53,10 +53,6 @@
     // This will override "match_only_adjacet" and "bracket_outside_adjacent".
     "block_cursor_mode": false,
 
-    // EXPERIMENTAL: When in block cursor mode, only highlight when the cursor
-    // is on (or selecting) either the opening or closing bracket.
-    "block_cursor_selected_only": false,
-
     // When "bracket_outside_adjacet" is set, and a plugin command explicitly sets
     // "no_outside_adj" to "None" instead of "true" or the default "false",
     // this value will be used.

--- a/bh_core.sublime-settings
+++ b/bh_core.sublime-settings
@@ -47,8 +47,15 @@
     // Outside adjacent bracket matching
     "bracket_outside_adjacent": true,
 
-    // Special matching mode for block cursor
+    // EXPERIMENTAL: Special matching mode for block cursor.
+    // Essentially, this provides a matching mode that makes a little more
+    // sense to some in regards to the visual representation of block cursors.
+    // This will override "match_only_adjacet" and "bracket_outside_adjacent".
     "block_cursor_mode": false,
+
+    // EXPERIMENTAL: When in block cursor mode, only highlight when the cursor
+    // is on (or selecting) either the opening or closing bracket.
+    "block_cursor_selected_only": false,
 
     // When "bracket_outside_adjacet" is set, and a plugin command explicitly sets
     // "no_outside_adj" to "None" instead of "true" or the default "false",

--- a/bh_core.sublime-settings
+++ b/bh_core.sublime-settings
@@ -47,6 +47,9 @@
     // Outside adjacent bracket matching
     "bracket_outside_adjacent": true,
 
+    // Special matching mode for block cursor
+    "block_cursor_mode": false,
+
     // When "bracket_outside_adjacet" is set, and a plugin command explicitly sets
     // "no_outside_adj" to "None" instead of "true" or the default "false",
     // this value will be used.

--- a/bh_core.sublime-settings
+++ b/bh_core.sublime-settings
@@ -62,6 +62,11 @@
     // this value will be used.
     "ignore_outside_adjacent_in_plugin": true,
 
+    // When "block_cursor_mode" is set, and a plugin command explicitly sets
+    // "no_block_mode" to "None" instead of "true" or the default "false",
+    // this value will be used.
+    "ignore_block_mode_in_plugin": true,
+
     // Character threshold to search
     "search_threshold": 5000,
 

--- a/bh_modules/bracketselect.py
+++ b/bh_modules/bracketselect.py
@@ -22,65 +22,82 @@ class SelectBracket(bh_plugin.BracketPluginCommand):
         parent.
         """
 
-        if tags is None:
-            tags = DEFAULT_TAGS
-        current_left, current_right = self.selection[0].begin(), self.selection[0].end()
-        left, right = self.left, self.right
-        first, last = left.end, right.begin
+        self.tags = DEFAULT_TAGS if tags is None else tags
+        self.current_left, self.current_right = self.selection[0].begin(), self.selection[0].end()
+        first, last = self.left.end, self.right.begin
+
         if select == 'left':
-            if name in tags and left.size() > 1:
-                first, last = left.begin + 1, left.begin + 1
-                if first == current_left and last == current_right:
-                    self.refresh_match = True
-                    if alternate:
-                        first, last = right.begin + 1, right.begin + 1
-                    else:
-                        first, last = left.begin, left.begin
-            else:
-                first, last = left.end, left.end
-                if first == current_left and last == current_right:
-                    self.refresh_match = True
-                    if alternate:
-                        first, last = right.begin, right.begin
-                    else:
-                        first, last = left.begin, left.begin
+            first, last = self.select_left(name, first, last, alternate)
         elif select == 'right':
-            if left.end != right.end:
-                if name in tags and left.size() > 1:
-                    first, last = right.begin + 1, right.begin + 1
-                    if first == current_left and last == current_right:
-                        self.refresh_match = True
-                        if alternate:
-                            first, last = left.begin + 1, left.begin + 1
-                        else:
-                            first, last = right.end, right.end
-                else:
-                    first, last = right.begin, right.begin
-                    if first == current_left and last == current_right:
-                        self.refresh_match = True
-                        if alternate:
-                            first, last = left.end, left.end
-                        else:
-                            first, last = right.end, right.end
-            else:
-                # There is no second bracket, so just select the first
-                if name in tags and left.size() > 1:
-                    first, last = left.begin + 1, left.begin + 1
-                    if first == current_left and last == current_right:
-                        self.refresh_match = True
-                        if not alternate:
-                            first, last = left.end, left.end
-                else:
-                    first, last = right.end, right.end
-                    if first == current_left and last == current_right:
-                        self.refresh_match = True
-                        if not alternate:
-                            first, last = right.end, right.end
-        elif first == current_left and last == current_right or always_include_brackets:
-            first, last = left.begin, right.end
-            self.refresh_match = True
+            first, last = self.select_right(name, first, last, alternate)
+        elif first == self.current_left and last == self.current_right or always_include_brackets:
+            first, last = self.select_expand(first, last)
 
         self.selection = [sublime.Region(first, last)]
+
+    def select_left(self, name, first, last, alternate):
+        """Select the left bracket."""
+
+        if name in self.tags and self.left.size() > 1:
+            first, last = self.left.begin + 1, self.left.begin + 1
+            if first == self.current_left and last == self.current_right:
+                self.refresh_match = True
+                if alternate:
+                    first, last = self.right.begin + 1, self.right.begin + 1
+                else:
+                    first, last = self.left.begin, self.left.begin
+        else:
+            first, last = self.left.end, self.left.end
+            if first == self.current_left and last == self.current_right:
+                self.refresh_match = True
+                if alternate:
+                    first, last = self.right.begin, self.right.begin
+                else:
+                    first, last = self.left.begin, self.left.begin
+        return first, last
+
+    def select_right(self, name, first, last, alternate):
+        """Select the right bracket."""
+
+        if self.left.end != self.right.end:
+            if name in self.tags and self.left.size() > 1:
+                first, last = self.right.begin + 1, self.right.begin + 1
+                if first == self.current_left and last == self.current_right:
+                    self.refresh_match = True
+                    if alternate:
+                        first, last = self.left.begin + 1, self.left.begin + 1
+                    else:
+                        first, last = self.right.end, self.right.end
+            else:
+                first, last = self.right.begin, self.right.begin
+                if first == self.current_left and last == self.current_right:
+                    self.refresh_match = True
+                    if alternate:
+                        first, last = self.left.end, self.left.end
+                    else:
+                        first, last = self.right.end, self.right.end
+        else:
+            # Select the first because there is no second bracket.
+            if name in self.tags and self.left.size() > 1:
+                first, last = self.left.begin + 1, self.left.begin + 1
+                if first == self.current_left and last == self.current_right:
+                    self.refresh_match = True
+                    if not alternate:
+                        first, last = self.left.end, self.left.end
+            else:
+                first, last = self.right.end, self.right.end
+                if first == self.current_left and last == self.current_right:
+                    self.refresh_match = True
+                    if not alternate:
+                        first, last = self.right.end, self.right.end
+        return first, last
+
+    def select_expand(self, first, last):
+        """Expand content selection."""
+
+        first, last = self.left.begin, self.right.end
+        self.refresh_match = True
+        return first, last
 
 
 def plugin():

--- a/bh_rules.py
+++ b/bh_rules.py
@@ -181,14 +181,15 @@ class ScopeDefinition(object):
 class SearchRules(object):
     """Search rule object."""
 
-    def __init__(self, brackets, scopes, string_escape_mode, outside_adj):
+    def __init__(self, brackets, scopes, string_escape_mode, outside_adj, block_cursor):
         """Setup search rulel object."""
 
         self.bracket_rules = process_overrides(brackets)
         self.scope_rules = process_overrides(scopes)
         self.enabled = False
         self.string_escape_mode = string_escape_mode
-        self.outside_adj = outside_adj
+        self.outside_adj = outside_adj and not block_cursor
+        self.block_cursor = block_cursor
         self.sub_pattern = None
         self.pattern = None
 

--- a/docs/customize.md
+++ b/docs/customize.md
@@ -111,7 +111,7 @@ Augments the matching behavior and will trigger matching when the cursor is adja
 ### block_cursor_mode (EXPERIMENTAL)
 Modifies the bracket matching mode for block cursor.  The bracket matching mode is one that makes a little more sense to some people in regards to the visual representation of block cursors.  So if you are someone that uses block cursors and find that toggling [bracket_outside_adjacent](#bracket_outside_adjacent) still doesn't quite match brackets how you would like, you can give this setting a try.
 
-When this setting is enabled, both [match_only_adjacent](#match_only_adjacent) and [bracket_outside_adjacent](#bracket_outside_adjacent) will be ignored.
+When this setting is enabled, [bracket_outside_adjacent](#bracket_outside_adjacent) will be ignored.
 
 ```js
     // EXPERIMENTAL: Special matching mode for block cursor.
@@ -119,15 +119,6 @@ When this setting is enabled, both [match_only_adjacent](#match_only_adjacent) a
     // sense to some in regards to the visual representation of block cursors.
     // This will override "match_only_adjacent" and "bracket_outside_adjacent".
     "block_cursor_mode": false,
-```
-
-### block_cursor_selected_only (EXPERIMENTAL)
-When [block_cursor_mode](#block_cursor_mode) is enabled, this will force highlighting to only occur when the cursor is directly on either the opening or closing bracket.  This is the block mode equivalent of [match_only_adjacent](#match_only_adjacent).
-
-```js
-    // EXPERIMENTAL: When in block cursor mode, only highlight when the cursor
-    // is on (or selecting) either the opening or closing bracket.
-    "block_cursor_selected_only": false,
 ```
 
 ### ignore_outside_adjacent_in_plugin
@@ -138,6 +129,16 @@ Ignores the [bracket_outside_adjacent](#bracket_outside_adjacent) setting when r
     // "no_outside_adj" "None" instead of "true" or the default "false",
     // this value will be used.
     "ignore_outside_adjacent_in_plugin": true,
+```
+
+### ignore_block_mode_in_plugin (EXPERIMENTAL)
+Ignores the [block_cursor_mode](#block_cursor_mode) setting when running a plugin **if** the plugin sets `no_block_mode` to `null` (`null` for JSON or `None` in Python).
+
+```js
+    // When "block_cursor_mode" is set, and a plugin command explicitly sets
+    // "no_block_mode" to "None" instead of "true" or the default "false",
+    // this value will be used.
+    "ignore_block_mode_in_plugin": true,
 ```
 
 ### bracket_string_escape_mode

--- a/docs/customize.md
+++ b/docs/customize.md
@@ -107,6 +107,29 @@ Augments the matching behavior and will trigger matching when the cursor is adja
     // Outside adjacent bracket matching
     "bracket_outside_adjacent": true,
 ```
+
+### block_cursor_mode (EXPERIMENTAL)
+Modifies the bracket matching mode for block cursor.  The bracket matching mode is one that makes a little more sense to some people in regards to the visual representation of block cursors.  So if you are someone that uses block cursors and find that toggling [bracket_outside_adjacent](#bracket_outside_adjacent) still doesn't quite match brackets how you would like, you can give this setting a try.
+
+When this setting is enabled, both [match_only_adjacent](#match_only_adjacent) and [bracket_outside_adjacent](#bracket_outside_adjacent) will be ignored.
+
+```js
+    // EXPERIMENTAL: Special matching mode for block cursor.
+    // Essentially, this provides a matching mode that makes a little more
+    // sense to some in regards to the visual representation of block cursors.
+    // This will override "match_only_adjacent" and "bracket_outside_adjacent".
+    "block_cursor_mode": false,
+```
+
+### block_cursor_selected_only (EXPERIMENTAL)
+When [block_cursor_mode](#block_cursor_mode) is enabled, this will force highlighting to only occur when the cursor is directly on either the opening or closing bracket.  This is the block mode equivalent of [match_only_adjacent](#match_only_adjacent).
+
+```js
+    // EXPERIMENTAL: When in block cursor mode, only highlight when the cursor
+    // is on (or selecting) either the opening or closing bracket.
+    "block_cursor_selected_only": false,
+```
+
 ### ignore_outside_adjacent_in_plugin
 Ignores the [bracket_outside_adjacent](#bracket_outside_adjacent) setting when running a plugin **if** the plugin sets `no_outside_adj` to `null` (`null` for JSON or `None` in Python).
 


### PR DESCRIPTION
### Overview
A mode of bracket highlighting that leans that aims to match in a way that matches more intuitively with the visual representation of a block cursor.  One thing to note is that bracket navigation via the `bracketselect` bh_pluging will ignore block cursor mode when jumping between brackets; bracket selection will work fine with block cursor mode.

### Core change
It was noted that selection did not work at first with `bracketselect` as intended with the core as it was.  Traditionally BH would look at a selection and use the selection start as the center point to crawl out from to find brackets; this would be point `a` via `sel.a`.  Visually, the cursor is shown at point `b`, the end of the selection.  To be honest, `b` seems to make more sense in a visual sense and would allow `bracketselect` to work well with block cursor mode.  Because of this, internally BH now looks at point `b` instead of `a`.  While I don't think it will break peoples work flow, it is a non-backwards compatible change.