### PR TITLE
Add brackets for Lua

### DIFF
--- a/bh_core.sublime-settings
+++ b/bh_core.sublime-settings
@@ -417,6 +417,7 @@
             "close": "(?<=[\\s;])(end|until)\\b",
             "style": "default",
             "scope_exclude": ["string", "comment"],
+            "plugin_library": "bh_modules.luakeywords",
             "language_filter": "whitelist",
             "language_list": ["Lua"],
             "enabled": true

--- a/bh_core.sublime-settings
+++ b/bh_core.sublime-settings
@@ -409,6 +409,17 @@
             "language_filter": "whitelist",
             "language_list": ["fish"],
             "enabled": true
+        },
+        // Lua
+        {
+            "name": "lua",
+            "open": "(?<=[\\s;])(if|while|function|do|repeat)\\b",
+            "close": "(?<=[\\s;])(end|until)\\b",
+            "style": "default",
+            "scope_exclude": ["string", "comment"],
+            "language_filter": "whitelist",
+            "language_list": ["Lua"],
+            "enabled": true
         }
     ],
 

--- a/bh_modules/luakeywords.py
+++ b/bh_modules/luakeywords.py
@@ -1,0 +1,17 @@
+"""
+BracketHighlighter.
+
+Copyright (c) 2013 - 2015 Isaac Muse <isaacmuse@gmail.com>
+License: MIT
+"""
+
+
+def validate(name, bracket, bracket_side, bfr):
+    """Check if bracket is lowercase."""
+    return bfr[bracket.begin:bracket.end].islower()
+
+
+def compare(name, first, second, bfr):
+    """Differentiate 'repeat..until' from '*..end' brackets."""
+    brackets = (bfr[first.begin:first.end], bfr[second.begin:second.end])
+    return (brackets[0] == "repeat") ^ (brackets[1] == "end")


### PR DESCRIPTION
^title

Technically, `repeat` and `until` are their own kind of brackets, but it doesn't seem like you can have two different groups in a single pattern (i.e. capturing group 1 in open matches 1 in close, 2 ... 2 etc.) and you didn't add different brackets for php either, so I figured this would *just do*.

Edit: I just saw that you used `plugin_library` and `bh_modules.phpkeywords`. Should I do this as a plugin too?