### PR TITLE
Allows "class" and other keywords as keys in a hash in Ruby

### DIFF
--- a/bh_core.sublime-settings
+++ b/bh_core.sublime-settings
@@ -319,7 +319,7 @@
         // Ruby embedded HTML
         {
             "name": "ruby_embedded_html",
-            "open": "((?:(?<=<%)|(?<=^)|(?<==))\\s*\\b(?:if|begin|case)\\b(?!:)|(?:(?<=<%)|(?<=^))\\s*\\b(?:for|until|unless|while|class|module|def\\b[\\p{Ll}\\p{Lu}]*)\\b|(?<!:)\\bdo\\b(?!:))",
+            "open": "((?:(?<=<%)|(?<=^)|(?<==))\\s*\\b(?:if|begin|case)\\b(?!:)|(?:(?<=<%)|(?<=^))\\s*\\b(?:for|until|unless|while|class|module|def\\b[\\p{Ll}\\p{Lu}]*)\\b(?!:)|(?<!:)\\bdo\\b(?!:))",
             "close": "(?<=[\\s;])(end)\\b(?!:)",
             "style": "default",
             "scope_exclude": ["text.html", "source", "comment", "string"],
@@ -335,7 +335,7 @@
         // Ruby conditional statements
         {
             "name": "ruby",
-            "open": "((?:(?<=^)|(?<==))\\s*\\b(?:if|begin|case)\\b(?!:)|^\\s*\\b(?:for|until|unless|while|class|module|def\\b[\\p{Ll}\\p{Lu}]*)\\b|(?<!:)\\bdo\\b(?!:))",
+            "open": "((?:(?<=^)|(?<==))\\s*\\b(?:if|begin|case)\\b(?!:)|^\\s*\\b(?:for|until|unless|while|class|module|def\\b[\\p{Ll}\\p{Lu}]*)\\b(?!:)|(?<!:)\\bdo\\b(?!:))",
             "close": "(?<=[\\s;])(end)\\b(?!:)",
             "style": "default",
             "scope_exclude": ["string", "comment"],


### PR DESCRIPTION
Similar to https://github.com/facelessuser/BracketHighlighter/pull/251

This allows a bunch of keywords (for, until, unless, while, class and module) to be the keys in a hash without throwing off syntax highlighting.

For example if you have a hash:
```ruby
attrs = {
  class: "tag-input",
  id: "tags"
}
```

then the presence of `class` does not throw off the bracket highlighting