### PR TITLE
Correct opening keyword when using append operator

### DIFF
--- a/bh_core.sublime-settings
+++ b/bh_core.sublime-settings
@@ -319,7 +319,7 @@
         // Ruby embedded HTML
         {
             "name": "ruby_embedded_html",
-            "open": "((?:(?<=<%)|(?<=^)|(?<==))\\s*\\b(?:if|begin|case)\\b(?!:)|(?:(?<=<%)|(?<=^))\\s*\\b(?:for|until|unless|while|class|module|def\\b[\\p{Ll}\\p{Lu}]*)\\b(?!:)|(?<!:)\\bdo\\b(?!:))",
+            "open": "((?:(?<=<%)|(?<=^)|(?<==)|(?<=<<))\\s*\\b(?:if|begin|case)\\b(?!:)|(?:(?<=<%)|(?<=^))\\s*\\b(?:for|until|unless|while|class|module|def\\b[\\p{Ll}\\p{Lu}]*)\\b(?!:)|(?<!:)\\bdo\\b(?!:))",
             "close": "(?<=[\\s;])(end)\\b(?!:)",
             "style": "default",
             "scope_exclude": ["text.html", "source", "comment", "string"],
@@ -335,7 +335,7 @@
         // Ruby conditional statements
         {
             "name": "ruby",
-            "open": "((?:(?<=^)|(?<==))\\s*\\b(?:if|begin|case)\\b(?!:)|^\\s*\\b(?:for|until|unless|while|class|module|def\\b[\\p{Ll}\\p{Lu}]*)\\b(?!:)|(?<!:)\\bdo\\b(?!:))",
+            "open": "((?:(?<=^)|(?<==)|(?<=<<))\\s*\\b(?:if|begin|case)\\b(?!:)|^\\s*\\b(?:for|until|unless|while|class|module|def\\b[\\p{Ll}\\p{Lu}]*)\\b(?!:)|(?<!:)\\bdo\\b(?!:))",
             "close": "(?<=[\\s;])(end)\\b(?!:)",
             "style": "default",
             "scope_exclude": ["string", "comment"],


### PR DESCRIPTION
Fix problem with finding opening keyword when using append operator before `if`/`begin`/`case` keywords. Problem also described in #301.
In following example there was no opening keyword for `end`:
```ruby
@foo << if true
           1
        end
```
Now the behavior similar to use of simple assignment (in provided example opening keyword is `if`).