### PR TITLE
Added basic Pascal support

### DIFF
--- a/bh_core.sublime-settings
+++ b/bh_core.sublime-settings
@@ -446,6 +446,17 @@
             "language_list": ["LaTeX", "LaTeX (TikZ)", "knitr (Rnw)"],
             "sub_bracket_search": "true",
             "enabled": true
+        },
+        // Pascal
+        {
+            "name": "pascal",
+            "open": "(?<=[\\s;])(try|class|record|begin|unit|repeat)\\b",
+            "close": "(?<=[\\s;])(end|until)\\b",
+            "style": "default",
+            "scope_exclude": ["string", "comment"],
+            "language_filter": "whitelist",
+            "language_list": ["Pascal"],
+            "enabled": true
         }
     ],
 

--- a/bh_core.sublime-settings
+++ b/bh_core.sublime-settings
@@ -450,10 +450,11 @@
         // Pascal
         {
             "name": "pascal",
-            "open": "(?<=[\\s;])(try|class|record|begin|unit|repeat)\\b",
-            "close": "(?<=[\\s;])(end|until)\\b",
+            "open": "(?:(?<=^)|(?<=[\\s;]))(try|(?<=\\=\\s)class|(?<=\\=\\s)record|(?<=\\=\\s)interface|begin|unit|repeat)\\b",
+            "close": "(?<=[\\s;])(end\\.|end(?=[;\\s])|until(?=\\b))",
             "style": "default",
             "scope_exclude": ["string", "comment"],
+            "plugin_library": "bh_modules.pascalkeywords",
             "language_filter": "whitelist",
             "language_list": ["Pascal"],
             "enabled": true

--- a/bh_core.sublime-settings
+++ b/bh_core.sublime-settings
@@ -450,7 +450,7 @@
         // Pascal
         {
             "name": "pascal",
-            "open": "(?:(?<=^)|(?<=[\\s;]))(try|(?<=\\=\\s)class|(?<=\\=\\s)record|(?<=\\=\\s)interface|begin|repeat)\\b",
+            "open": "(?:(?<=^)|(?<=[\\s;]))(try|(?<=\\=\\s)(?:class|record|interface)|begin|repeat)\\b",
             "close": "(?<=[\\s;])(end(?=[;\\s])|until(?=\\s))",
             "style": "default",
             "scope_exclude": ["string", "comment"],

--- a/bh_core.sublime-settings
+++ b/bh_core.sublime-settings
@@ -450,8 +450,8 @@
         // Pascal
         {
             "name": "pascal",
-            "open": "(?:(?<=^)|(?<=[\\s;]))(try|(?<=\\=\\s)class|(?<=\\=\\s)record|(?<=\\=\\s)interface|begin|unit|repeat)\\b",
-            "close": "(?<=[\\s;])(end\\.|end(?=[;\\s])|until(?=\\b))",
+            "open": "(?:(?<=^)|(?<=[\\s;]))(try|(?<=\\=\\s)class|(?<=\\=\\s)record|(?<=\\=\\s)interface|begin|repeat)\\b",
+            "close": "(?<=[\\s;])(end(?=[;\\s])|until(?=\\s))",
             "style": "default",
             "scope_exclude": ["string", "comment"],
             "plugin_library": "bh_modules.pascalkeywords",

--- a/bh_modules/pascalkeywords.py
+++ b/bh_modules/pascalkeywords.py
@@ -4,7 +4,6 @@ BracketHighlighter.
 Copyright (c) 2013 - 2015 Isaac Muse <isaacmuse@gmail.com>
 License: MIT
 """
-from BracketHighlighter.bh_plugin import import_module
 
 
 def compare(name, first, second, bfr):

--- a/bh_modules/pascalkeywords.py
+++ b/bh_modules/pascalkeywords.py
@@ -1,0 +1,15 @@
+"""
+BracketHighlighter.
+
+Copyright (c) 2013 - 2015 Isaac Muse <isaacmuse@gmail.com>
+License: MIT
+"""
+from BracketHighlighter.bh_plugin import import_module
+
+
+def compare(name, first, second, bfr):
+    """Differentiate 'repeat..until' and 'unit..end.' from '*..end' brackets."""
+    brackets = (bfr[first.begin:first.end], bfr[second.begin:second.end])
+    return (brackets[0] == "repeat" and brackets[1] == "until") \
+        or (brackets[0] == "unit" and brackets[1] == "end.") \
+        or (brackets[0] != "repeat" and brackets[0] != "unit" and (brackets[1] == "end"))

--- a/bh_modules/pascalkeywords.py
+++ b/bh_modules/pascalkeywords.py
@@ -7,8 +7,6 @@ License: MIT
 
 
 def compare(name, first, second, bfr):
-    """Differentiate 'repeat..until' and 'unit..end.' from '*..end' brackets."""
+    """Differentiate 'repeat..until' from '*..end' brackets."""
     brackets = (bfr[first.begin:first.end], bfr[second.begin:second.end])
-    return (brackets[0] == "repeat" and brackets[1] == "until") \
-        or (brackets[0] == "unit" and brackets[1] == "end.") \
-        or (brackets[0] != "repeat" and brackets[0] != "unit" and (brackets[1] == "end"))
+    return (brackets[0] == "repeat") ^ (brackets[1] == "end")

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -32,6 +32,7 @@ BH supports a variety of brackets out of the box; here are some examples:
 - Bash conditional and looping constructs
 - Fish conditional and looping constructs
 - Lua
+- Pascal
 
 Within supported regex and strings, BH can also highlight basic sub brackets between the matched quotes: `(), [], {}`.
 


### PR DESCRIPTION
In pascal, keywords are used to open and close blocks, classes, etc.  This adds preliminary support for Pascal.  ~~It isn't perfect, since `class` is a keyword in a few other contexts as well, but it works in most cases.~~  It works for most of the examples I've tried.