### PR TITLE
Support for markdown code inline and code blocks

### DIFF
--- a/bh_core.sublime-settings
+++ b/bh_core.sublime-settings
@@ -216,8 +216,8 @@
         },
         {
             "name": "mdcodeblock",
-            "open": "\\s*(```)",
-            "close": "(```)\\n?",
+            "open": "\\s*(`{3,})",
+            "close": "(`{3,})\\n?",
             "style": "default",
             "scopes": ["markup.raw.block.fenced.markdown"],
             "language_filter": "whitelist",

--- a/bh_core.sublime-settings
+++ b/bh_core.sublime-settings
@@ -216,8 +216,8 @@
         },
         {
             "name": "mdcodeblock",
-            "open": "\\s*(`{3,})",
-            "close": "(`{3,})\\n?",
+            "open": "\\s*(`{3,}|~{3,})",
+            "close": "(`{3,}|~{3,})\\n?",
             "style": "default",
             "scopes": ["markup.raw.block.fenced.markdown"],
             "language_filter": "whitelist",

--- a/bh_core.sublime-settings
+++ b/bh_core.sublime-settings
@@ -203,6 +203,28 @@
             "sub_bracket_search": "true",
             "enabled": true
         },
+        {
+            "name": "mdcodeinline",
+            "open": "(`+)",
+            "close": "(`+)",
+            "style": "default",
+            "scopes": ["markup.raw.inline.markdown"],
+            "language_filter": "whitelist",
+            "language_list": ["Markdown"],
+            "sub_bracket_search": "true",
+            "enabled": true
+        },
+        {
+            "name": "mdcodeblock",
+            "open": "\\s*(```)",
+            "close": "(```)\\n?",
+            "style": "default",
+            "scopes": ["markup.raw.block.fenced.markdown"],
+            "language_filter": "whitelist",
+            "language_list": ["Markdown"],
+            "sub_bracket_search": "true",
+            "enabled": true
+        },
         // LaTeX
         {
             "name": "latexmath_inline",

--- a/bh_core.sublime-settings
+++ b/bh_core.sublime-settings
@@ -212,6 +212,7 @@
             "language_filter": "whitelist",
             "language_list": ["Markdown"],
             "sub_bracket_search": "true",
+            "plugin_library": "bh_modules.mdcodeinline",
             "enabled": true
         },
         {

--- a/bh_modules/mdcodeinline.py
+++ b/bh_modules/mdcodeinline.py
@@ -8,10 +8,6 @@ License: MIT
 
 def post_match(view, name, style, first, second, center, bfr, threshold):
     """Ensure that backticks inside the inline are not highlighted."""
-    # ensure this is only used for inline markdown
-    if name != "mdcodeinline":
-        return first, second, style
-
     inline_content_scope = "markup.raw.inline.content.markdown"
     # move the first scope back to the left
     if first is not None:

--- a/bh_modules/mdcodeinline.py
+++ b/bh_modules/mdcodeinline.py
@@ -1,0 +1,22 @@
+"""
+BracketHighlighter.
+
+Copyright (c) 2013 - 2015 Isaac Muse <isaacmuse@gmail.com>
+License: MIT
+"""
+
+
+def post_match(view, name, style, first, second, center, bfr, threshold):
+    """Ensure that backticks inside the inline are not highlighted."""
+    # ensure this is only used for inline markdown
+    if name != "mdcodeinline":
+        return first, second, style
+
+    inline_content_scope = "markup.raw.inline.content.markdown"
+    # move the first scope back to the left
+    if first is not None:
+        end = first.end
+        while view.score_selector(end - 1, inline_content_scope):
+            end -= 1
+        first = first.move(first.begin, end)
+    return first, second, style


### PR DESCRIPTION
This PR adds support for backticks in markdown. This is used for code highlighting. `` ` `` for inline code and  ```` ``` ```` for code blocks.

![bh_md_code_backticks](https://cloud.githubusercontent.com/assets/12573621/13889658/08c67602-ed48-11e5-8202-48b08b38b0f4.png)