### PR TITLE
ignore RTF language for square and round brackets

### DIFF
--- a/bh_core.sublime-settings
+++ b/bh_core.sublime-settings
@@ -254,7 +254,7 @@
                 "source.yaml-tmlanguage constant.character.escape"
             ],
             "language_filter": "blacklist",
-            "language_list": ["Plain text", "Hex"],
+            "language_list": ["Plain text", "Hex", "RTF"],
             "find_in_sub_search": "true",
             "ignore_string_escape": true,
             "enabled": true
@@ -267,7 +267,7 @@
             "scope_exclude": ["string", "comment"],
             "scope_exclude_exceptions": ["text.tex string.other.math", "source.yaml-tmlanguage meta.value -constant.character.escape"],
             "language_filter": "blacklist",
-            "language_list": ["Plain text", "Hex"],
+            "language_list": ["Plain text", "Hex", "RTF"],
             "find_in_sub_search": "true",
             "ignore_string_escape": true,
             "enabled": true


### PR DESCRIPTION
add RTF language to blacklist for square and round brackets, to ensure
that curly braces are always matched properly in RTF documents.

(square and round brackets have no meaning in RTF, and are just plain text, but curly braces are significant)