### PR TITLE
Add support for new LaTeX Syntax

### DIFF
--- a/bh_core.sublime-settings
+++ b/bh_core.sublime-settings
@@ -271,7 +271,7 @@
             "open": "(\\$)",
             "close": "(\\$)",
             "style": "default",
-            "scopes": ["string.other.math.tex"],
+            "scopes": ["string.other.math.tex", "meta.environment.math.inline.dollar.latex"],
             "language_filter": "whitelist",
             "language_list": ["LaTeX", "LaTeX (TikZ)", "knitr (Rnw)"],
             "sub_bracket_search": "true",


### PR DESCRIPTION
The rewrite of the LaTeX Syntax https://github.com/sublimehq/Packages/pull/370 changes the scope of inline math commands `$...$`. Hence this PR adds the new scope, such that it will still work after the release of the new syntax.