### PR TITLE
Changed 'Example.sublime-keymaps' to singular 'Example.sublime-keymap'

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -94,7 +94,7 @@ Selects the opening and closing tag name of current tag.
 Swaps the current surrounding bracket with different supported brackets of your choice.  Swapping definitions are configured in `bh_swapping.sublime-settings`.
 
 ## Shortcuts
-BH provides no shortcuts in order to avoid shortcut conflicts, but you can view the included `Example.sublime-keymaps` file to get an idea how to set up your own.
+BH provides no shortcuts in order to avoid shortcut conflicts, but you can view the included [`Example.sublime-keymap`](https://github.com/facelessuser/BracketHighlighter/blob/master/Example.sublime-keymap) file to get an idea how to set up your own.
 
 *[BH]: BracketHighlighter
 *[ST2]: Sublime Text 2


### PR DESCRIPTION
Updated the documentation so that 'Example.sublime-keymaps' is reflected as 'Example.sublime-keymap', making it able to be searched for in the github repo. Also added a link to the 'Example.sublime-keymap' github repo file.

Thanks you for contributing to this project!  Make sure you've read: http://facelessuser.github.io/BracketHighlighter/contributing/.  Please follow the guidelines below.

- Please describe the change in as much detail as possible so I can understand what is being added or modified.

- If you are solving a bug that does not already have an issue, please describe the bug in detail and provide info on how to reproduce if applicable (this is good for me and others to reference later when verifying the issue has been resolved).

- Please reference and link related open bugs or feature requests in this pull if applicable.

- Make sure you've documented or updated the existing documentation if introducing a new feature or modifying the behavior of an existing feature that a user needs to be aware of.  I will not accept new features if you have not provided documentation describing the feature.
