### PR TITLE
add backtick quote support for ruby and shell script syntaxes

### DIFF
--- a/bh_core.sublime-settings
+++ b/bh_core.sublime-settings
@@ -184,6 +184,17 @@
             "sub_bracket_search": "true",
             "enabled": true
         },
+        {
+            "name": "backtick_quote",
+            "open": "(`)",
+            "close": "(`)",
+            "style": "single_quote",
+            "scopes": ["string.interpolated.ruby", "string.interpolated.backtick.shell"],
+            "language_filter": "whitelist",
+            "language_list": ["Ruby", "Shell-Unix-Generic"],
+            "sub_bracket_search": "true",
+            "enabled": true
+        },
         // Regex for different Languages
         {
             "name": "jsregex",


### PR DESCRIPTION
Thanks you for contributing to this project!  Make sure you've read: http://facelessuser.github.io/BracketHighlighter/contributing/.  Please follow the guidelines below.

We've discussed this in issue #395.
