### PR TITLE
Added `Markdown Extended` as Markdown syntax and '`' as (swap/wrap)pable

### DIFF
--- a/bh_core.sublime-settings
+++ b/bh_core.sublime-settings
@@ -237,7 +237,7 @@
             "style": "default",
             "scopes": ["markup.italic"],
             "language_filter": "whitelist",
-            "language_list": ["Markdown", "Multimarkdown", "GithubFlavoredMarkdown"],
+            "language_list": ["Markdown", "Multimarkdown", "GithubFlavoredMarkdown", "Markdown Extended"],
             "sub_bracket_search": "true",
             "enabled": true
         },
@@ -248,7 +248,7 @@
             "style": "default",
             "scopes": ["markup.bold"],
             "language_filter": "whitelist",
-            "language_list": ["Markdown", "Multimarkdown", "GithubFlavoredMarkdown"],
+            "language_list": ["Markdown", "Multimarkdown", "GithubFlavoredMarkdown", "Markdown Extended"],
             "sub_bracket_search": "true",
             "enabled": true
         },
@@ -259,7 +259,7 @@
             "style": "default",
             "scopes": ["markup.raw.inline.markdown"],
             "language_filter": "whitelist",
-            "language_list": ["Markdown", "Multimarkdown", "GithubFlavoredMarkdown"],
+            "language_list": ["Markdown", "Multimarkdown", "GithubFlavoredMarkdown", "Markdown Extended"],
             "sub_bracket_search": "true",
             "plugin_library": "bh_modules.mdcode",
             "enabled": true
@@ -271,7 +271,7 @@
             "style": "default",
             "scopes": ["markup.raw.block.fenced.markdown, markup.raw.block.markdown.fenced"],
             "language_filter": "whitelist",
-            "language_list": ["Markdown", "Multimarkdown", "GithubFlavoredMarkdown"],
+            "language_list": ["Markdown", "Multimarkdown", "GithubFlavoredMarkdown", "Markdown Extended"],
             "plugin_library": "bh_modules.mdcode",
             "sub_bracket_search": "true",
             "enabled": true

--- a/bh_swapping.sublime-settings
+++ b/bh_swapping.sublime-settings
@@ -26,9 +26,10 @@
             ]
         },
         {
-            "enabled": true, "language_list": ["Markdown"], "language_filter": "whitelist", "entries": [
+            "enabled": true, "language_list": ["Markdown", "Multimarkdown", "GithubFlavoredMarkdown", "Markdown Extended"], "language_filter": "whitelist", "entries": [
                 {"name": "Mardown: Bold", "brackets": ["**", "**${BH_SEL}"]},
-                {"name": "Mardown: Italic", "brackets": ["_", "_${BH_SEL}"]}
+                {"name": "Mardown: Italic", "brackets": ["_", "_${BH_SEL}"]},
+                {"name": "Mardown: Monospace", "brackets": ["`", "`${BH_SEL}"]}
             ]
         },
         {

--- a/bh_wrapping.sublime-settings
+++ b/bh_wrapping.sublime-settings
@@ -38,9 +38,10 @@
             ]
         },
         {
-            "enabled": true, "language_list": ["Markdown"], "language_filter": "whitelist", "entries": [
+            "enabled": true, "language_list": ["Markdown", "Multimarkdown", "GithubFlavoredMarkdown", "Markdown Extended"], "language_filter": "whitelist", "entries": [
                 {"name": "Mardown: Bold", "brackets": ["**", "**${BH_SEL}"]},
-                {"name": "Mardown: Italic", "brackets": ["_", "_${BH_SEL}"]}
+                {"name": "Mardown: Italic", "brackets": ["_", "_${BH_SEL}"]},
+                {"name": "Mardown: Monospace", "brackets": ["`", "`${BH_SEL}"]}
             ]
         },
         {


### PR DESCRIPTION
Implemented the following changes:

- Added `Markdown Extended` as Markdown syntax in all places
- Added the Monospace `` as a swappable and wrappable bracket in Markdown