### PR TITLE
Fix PHP angle issue on Sublime Build 3153+

### DIFF
--- a/bh_core.sublime-settings
+++ b/bh_core.sublime-settings
@@ -379,7 +379,8 @@
                 "source.ruby.rails.embedded.html",
                 "source.ruby.embedded.html",
                 "storage.type.function.arrow.js",
-                "punctuation.accessor.php"
+                "punctuation.accessor.php",
+                "punctuation.accessor.arrow.php"
             ],
             "language_filter": "whitelist",
             "language_list": [


### PR DESCRIPTION
Sublime Text Build 3153 has introduced newer scopes for syntax
highlighting which breaks the support for PHP. If a angle `->` is
present, then it breaks the bracket matching. The new introduced
scope for `$var->prop` is "punctuation.accessor.arrow.php" so we
add that to the exclusion list.