### PR TITLE
C# verbatim & interpolated strings (@"…", $"…")

### DIFF
--- a/bh_core.sublime-settings
+++ b/bh_core.sublime-settings
@@ -161,6 +161,17 @@
             "enabled": true
         },
         {
+            "name": "csharp_double_quote",
+            "open": "\\$?@?(\")",
+            "close": "(\")",
+            "style": "double_quote",
+            "scopes": ["string.quoted.double", "meta.string.interpolated"],
+            "language_filter": "whitelist",
+            "language_list": ["C#"],
+            "sub_bracket_search": "true",
+            "enabled": true
+        },
+        {
             "name": "single_quote",
             "open": "(')",
             "close": "(')",


### PR DESCRIPTION
Match quotes for [C# verbatim strings,][v] included in the default ST3 C# package syntax as `string.quoted.double.raw.cs`.
Match quotes for [C# interpolated strings][i] unless they are (a) multiline and (b) contain interpolation. (An update to the C# package will fix the exception.)

```cs
var literal = "foo";
var interpolated_none = $"foo";
var interpolated_yes = $"foo {bar} foo";
var verbatim_singleline = @"foo";
var verbatim_singleline_interpolated_none = $@"foo bar";
var verbatim_singleline_interpolated_yes = $@"foo {bar} foo";
var verbatim_multiline = @"foo
bar
baz";
var verbatim_multiline_interpolated_none = $@"foo
bar
baz";
var verbatim_multiline_interpolated_yes = $@"foo
{bar}
baz";
```

[v]: https://github.com/dotnet/csharplang/blob/master/spec/lexical-structure.md#string-literals
[i]: https://github.com/dotnet/csharplang/blob/master/spec/expressions.md#interpolated-strings