### PR TITLE
Bracket rules for C/C++ updated

### DIFF
--- a/bh_core.sublime-settings
+++ b/bh_core.sublime-settings
@@ -457,12 +457,12 @@
         // C/C++ compile switches
         {
             "name": "c_compile_switch",
-            "open": "(\\#(?:if|ifdef|ifndef))\\b",
-            "close": "(\\#endif)\\b",
+            "open": "(\\#\\s*(?:if|ifdef|ifndef))\\b",
+            "close": "(\\#\\s*endif)\\b",
             "style": "c_define",
             "scope_exclude": ["string", "comment"],
             "language_filter": "whitelist",
-            "language_list": ["C++", "C", "Objective-C", "CCpp", "C Improved"],
+            "language_list": ["C++", "C", "Objective-C++", "Objective-C", "CCpp", "C Improved"],
             "enabled": true
         },
         // PHP conditional keywords

--- a/bh_core.sublime-settings
+++ b/bh_core.sublime-settings
@@ -457,8 +457,8 @@
         // C/C++ compile switches
         {
             "name": "c_compile_switch",
-            "open": "(\\#\\s*(?:if|ifdef|ifndef))\\b",
-            "close": "(\\#\\s*endif)\\b",
+            "open": "(\\#[ \\t]*(?:if|ifdef|ifndef))\\b",
+            "close": "(\\#[ \\t]*endif)\\b",
             "style": "c_define",
             "scope_exclude": ["string", "comment"],
             "language_filter": "whitelist",


### PR DESCRIPTION
+ Support `Objective-C++` syntax as well.
+ Spaces after the `#` is a very common practice so it should be supported:
   `#if`/`#ifdef`/`#ifndef` with spaces such as:

```c
#ifdef FOO
#  ifdef BAR
#    undef BAR
#  endif
#else
#  define BAR
#endif
```
