### PR TITLE
Add instruction for how to disable all gutter icons

### DIFF
--- a/bh_core.sublime-settings
+++ b/bh_core.sublime-settings
@@ -620,6 +620,8 @@
     // the official list, and do not need to be inserted before
     // one of the official definitions, this is a good place to
     // put yours rules and keep in sync with the defaults.
+    // If you want to disable all gutter icons, please set icon
+    // to none for all region with user_bracket_styles
     "user_scope_brackets": [],
     "user_brackets": [],
     "user_bracket_styles": {},


### PR DESCRIPTION
## Why is this change necessary?

- People are querying about how to disable all gutter icons
  - https://github.com/facelessuser/BracketHighlighter/issues/294
  - https://github.com/facelessuser/BracketHighlighter/issues/335
  - https://github.com/facelessuser/BracketHighlighter/issues/472
- There was no direct instruction on how to do that in Default Settings

## How does it address the issue?

- Add a comment in Default Settings to hint how to disable all gutter icons.
- The comment contains the keyword "gutter".

## Takeaway: How to disable all gutter icons

1. Open "Sublime Text > Preferences > Package Settings > BracketHighlighter > Bracket Settings"
2. In `bh_core.sublime-settings - User` window (right-hand side), insert:

```
    "user_bracket_styles": {
        "default":      { "icon": "none" },
        "unmatched":    { "icon": "none" },
        "curly":        { "icon": "none" },
        "round":        { "icon": "none" },
        "square":       { "icon": "none" },
        "angle":        { "icon": "none" },
        "tag":          { "icon": "none" },
        "c_define":     { "icon": "none" },
        "single_quote": { "icon": "none" },
        "double_quote": { "icon": "none" },
        "regex":        { "icon": "none" }
    }
```