### PR TITLE
Add jump to matching bracket example

### DIFF
--- a/Example.sublime-keymap
+++ b/Example.sublime-keymap
@@ -57,6 +57,20 @@
         "keys": ["ctrl+alt+super+x"],
         "command": "bh_toggle_string_escape_mode"
     },
+    // Jump to matching bracket
+    {
+        "keys": ["ctrl+m"],
+        "command": "bh_key",
+        "args": {
+            "plugin": {
+                "args": {"select": "right", "alternate": true},
+                "command": "bh_modules.bracketselect",
+                "type": ["__all__"]
+            },
+            "lines": true,
+            "no_outside_adj": null
+        }
+    },
     // Select text between brackets
     {
         "no_outside_adj": null,


### PR DESCRIPTION
This change simply adds an example of how to re-implement the standard "Jump to matching bracket" feature that installing this plugin disables when used with the recommended settings.

Fixes #405