### PR TITLE
Added `user_swapping` and `user_wrapping`

### DIFF
--- a/bh_swapping.py
+++ b/bh_swapping.py
@@ -70,7 +70,7 @@ class SwapBracketsCommand(sublime_plugin.TextCommand):
 
         self.async = async
         self.window = self.view.window()
-        self.wrap = SwapBrackets(self.view, "bh_swapping.sublime-settings", "swapping")
+        self.wrap = SwapBrackets(self.view, "bh_swapping.sublime-settings", "swapping", "user_swapping")
 
         if len(self.wrap._menu):
             self.window.show_quick_panel(

--- a/bh_swapping.sublime-settings
+++ b/bh_swapping.sublime-settings
@@ -47,5 +47,11 @@
                 {"name": "C/C++: #ifndef, #else", "brackets": ["#ifndef${BH_SEL}", "#else\n${BH_TAB:/* CODE */}\n#endif"]}
             ]
         }
-    ]
+    ],
+    // user_swapping will be appended to the tail of swapping
+    // If you have custom rules that you don't want to commit to
+    // the official list, and do not need to be inserted before
+    // one of the official definitions, this is a good place to
+    // put yours rules and keep in sync with the defaults.
+    "user_swapping": [],
 }

--- a/bh_wrapping.py
+++ b/bh_wrapping.py
@@ -100,7 +100,7 @@ class ExecuteWrapInstanceCommand(sublime_plugin.TextCommand):
 class WrapBrackets(object):
     """Wrap the current selection(s) with the defined wrapping options."""
 
-    def __init__(self, view, setting_file, attribute):
+    def __init__(self, view, setting_file, attribute, user_attribute):
         """Init."""
 
         self.view = view
@@ -108,7 +108,7 @@ class WrapBrackets(object):
         self._brackets = []
         self._insert = []
         self._style = []
-        self.read_wrap_entries(setting_file, attribute)
+        self.read_wrap_entries(setting_file, attribute, user_attribute)
 
     def inline(self, edit, sel):
         """Inline wrap."""
@@ -230,13 +230,13 @@ class WrapBrackets(object):
         elif len(final_sel):
             self.view.sel().add(final_sel[0])
 
-    def read_wrap_entries(self, setting_file, attribute):
+    def read_wrap_entries(self, setting_file, attribute, user_attribute):
         """Read wrap entries from the settings file."""
 
         settings = sublime.load_settings(setting_file)
         syntax = self.view.settings().get('syntax')
         language = splitext(basename(syntax))[0].lower() if syntax is not None else "plain text"
-        wrapping = settings.get(attribute, [])
+        wrapping = settings.get(attribute, []) + settings.get(user_attribute, [])
         for i in wrapping:
             if not exclude_entry(i["enabled"], i["language_filter"], i["language_list"], language):
                 for j in i.get("entries", []):
@@ -302,7 +302,7 @@ class WrapBracketsCommand(sublime_plugin.TextCommand, WrapBrackets):
         self._brackets = []
         self._insert = []
         self._style = []
-        self.read_wrap_entries("bh_wrapping.sublime-settings", "wrapping")
+        self.read_wrap_entries("bh_wrapping.sublime-settings", "wrapping", "user_wrapping")
 
         if len(self._menu):
             self.view.window().show_quick_panel(

--- a/bh_wrapping.sublime-settings
+++ b/bh_wrapping.sublime-settings
@@ -73,5 +73,11 @@
                 {"name": "CSS: @group", "brackets": ["/* @group ${BH_SEL:NAME} */", "/* @end */"], "insert_style": ["block"]}
             ]
         }
-    ]
+    ],
+    // user_swapping will be appended to the tail of swapping
+    // If you have custom rules that you don't want to commit to
+    // the official list, and do not need to be inserted before
+    // one of the official definitions, this is a good place to
+    // put yours rules and keep in sync with the defaults.
+    "user_swapping": [],
 }

--- a/docs/src/markdown/customize.md
+++ b/docs/src/markdown/customize.md
@@ -675,7 +675,7 @@ Parameters                   | Description
 
 ### Bracket Rule Management
 
-In the past, BracketHighlighter required a user to copy the entire bracket list to the user `bh_core.sublime-settings` file.  This was a cumbersome requirement that also punished a user because if they did this, they wouldn't automatically get updates to the rules as all the rules were now overridden by the user's settings file.
+In the past, BracketHighlighter required a user to copy the entire bracket list to the user `bh_core.sublime-settings`/`bh_swapping.sublime-settings`/`bh_wrapping.sublime-settings` file.  This was a cumbersome requirement that also punished a user because if they did this, they wouldn't automatically get updates to the rules as all the rules were now overridden by the user's settings file.
 
 BracketHighlighter now lets you add or modify existing rules without overriding the entire rule set, or even the entire target rule.  Let's say you have a custom language you want to have on your machine. Now, you can simply add it to one of the two settings arrays: "user_scope_brackets" and "user_brackets":
 


### PR DESCRIPTION
I added a new `user_swapping` and `user_wrapping` functionality mirroring the `user_brackets` and `user_scope_brackets` functionality to allow users to override some of the upstream options without losing out on future updates.


Thanks you for contributing to this project!  Make sure you've read: http://facelessuser.github.io/BracketHighlighter/contributing/.  Please follow the guidelines below.

- Please describe the change in as much detail as possible so I can understand what is being added or modified.

- If you are solving a bug that does not already have an issue, please describe the bug in detail and provide info on how to reproduce if applicable (this is good for me and others to reference later when verifying the issue has been resolved).

- Please reference and link related open bugs or feature requests in this pull if applicable.

- Make sure you've documented or updated the existing documentation if introducing a new feature or modifying the behavior of an existing feature that a user needs to be aware of.  I will not accept new features if you have not provided documentation describing the feature.