### PR TITLE
Fix ShellScript `case` exclusion

### DIFF
--- a/bh_core.sublime-settings
+++ b/bh_core.sublime-settings
@@ -365,7 +365,7 @@
                 "string",
                 "comment",
                 "source.regexp constant.character.escape",
-                "punctuation.definition.case-pattern.shell",
+                "keyword.control.conditional.patterns.end.shell",
                 "source.yaml-tmlanguage constant.character.escape"
             ],
             "language_filter": "blacklist",


### PR DESCRIPTION
The main syntax definition changed. This brings BH in line with it.

This fixes the attempted bracket highlight of `)` in shell `case ... esac` statements.