### PR TITLE
Fix Markdown typo in swap and wrap commands

### DIFF
--- a/bh_swapping.sublime-settings
+++ b/bh_swapping.sublime-settings
@@ -27,9 +27,9 @@
         },
         {
             "enabled": true, "language_list": ["Markdown", "Multimarkdown", "GithubFlavoredMarkdown", "Markdown Extended"], "language_filter": "whitelist", "entries": [
-                {"name": "Mardown: Bold", "brackets": ["**", "**${BH_SEL}"]},
-                {"name": "Mardown: Italic", "brackets": ["_", "_${BH_SEL}"]},
-                {"name": "Mardown: Monospace", "brackets": ["`", "`${BH_SEL}"]}
+                {"name": "Markdown: Bold", "brackets": ["**", "**${BH_SEL}"]},
+                {"name": "Markdown: Italic", "brackets": ["_", "_${BH_SEL}"]},
+                {"name": "Markdown: Monospace", "brackets": ["`", "`${BH_SEL}"]}
             ]
         },
         {

--- a/bh_wrapping.sublime-settings
+++ b/bh_wrapping.sublime-settings
@@ -39,9 +39,9 @@
         },
         {
             "enabled": true, "language_list": ["Markdown", "Multimarkdown", "GithubFlavoredMarkdown", "Markdown Extended"], "language_filter": "whitelist", "entries": [
-                {"name": "Mardown: Bold", "brackets": ["**", "**${BH_SEL}"]},
-                {"name": "Mardown: Italic", "brackets": ["_", "_${BH_SEL}"]},
-                {"name": "Mardown: Monospace", "brackets": ["`", "`${BH_SEL}"]}
+                {"name": "Markdown: Bold", "brackets": ["**", "**${BH_SEL}"]},
+                {"name": "Markdown: Italic", "brackets": ["_", "_${BH_SEL}"]},
+                {"name": "Markdown: Monospace", "brackets": ["`", "`${BH_SEL}"]}
             ]
         },
         {


### PR DESCRIPTION
Change `Mardown` to `Markdown` in the command palette for both swap and wrap Markdown syntax commands.