### PR TITLE
Fix CFML Syntax highlighting

### DIFF
--- a/bh_core.sublime-settings
+++ b/bh_core.sublime-settings
@@ -445,6 +445,7 @@
                 "HTML (Jinja2)",
                 "HTML (Twig)",
                 "HTML (Django)",
+                "CFML",
                 "HTML+CFML",
                 "ColdFusion",
                 "ColdFusionCFC",
@@ -525,6 +526,7 @@
                 "HTML",
                 "HTML 5",
                 "PHP",
+                "CFML",
                 "HTML+CFML",
                 "ColdFusion",
                 "ColdFusionCFC"

--- a/bh_swapping.sublime-settings
+++ b/bh_swapping.sublime-settings
@@ -21,7 +21,7 @@
             ]
         },
         {
-            "enabled": true, "language_list": ["HTML", "HTML 5", "XML", "PHP", "HTML+CFML", "ColdFusion", "ColdFusionCFC"], "language_filter": "whitelist", "entries": [
+            "enabled": true, "language_list": ["HTML", "HTML 5", "XML", "PHP", "CFML", "HTML+CFML", "ColdFusion", "ColdFusionCFC"], "language_filter": "whitelist", "entries": [
                 {"name": "HTML/XML Tag", "brackets": ["<${BH_SEL:NAME}>", "</${BH_SEL:NAME}>"]}
             ]
         },

--- a/bh_tag.sublime-settings
+++ b/bh_tag.sublime-settings
@@ -46,7 +46,7 @@
         },
         {
             "mode": "cfml",
-            "syntax": ["HTML+CFML", "ColdFusion", "ColdFusionCFC"]
+            "syntax": ["CFML", "HTML+CFML", "ColdFusion", "ColdFusionCFC"]
         }
     ],
 

--- a/bh_wrapping.sublime-settings
+++ b/bh_wrapping.sublime-settings
@@ -33,7 +33,7 @@
             ]
         },
         {
-            "enabled": true, "language_list": ["HTML", "HTML 5", "XML", "PHP", "HTML+CFML", "ColdFusion", "ColdFusionCFC"], "language_filter": "whitelist", "entries": [
+            "enabled": true, "language_list": ["HTML", "HTML 5", "XML", "PHP", "CFML", "HTML+CFML", "ColdFusion", "ColdFusionCFC"], "language_filter": "whitelist", "entries": [
                 {"name": "HTML/XML Tag", "brackets": ["<${BH_SEL:NAME}>", "</${BH_SEL:NAME}>"], "insert_style": ["inline", "block", "indent_block"]}
             ]
         },

--- a/docs/src/markdown/customize.md
+++ b/docs/src/markdown/customize.md
@@ -372,7 +372,7 @@ A list that contains a dictionary of different modes.  Each mode tweaks the tag 
         },
         {
             "mode": "cfml",
-            "syntax": ["HTML+CFML", "ColdFusion", "ColdFusionCFC"]
+            "syntax": ["CFML", "HTML+CFML", "ColdFusion", "ColdFusionCFC"]
         }
     ],
 ```
@@ -607,7 +607,7 @@ Brackets are defined under `brackets` in `bh_core.sublime-settings`.
             "style": "angle",
             "scope_exclude": ["string", "comment", "keyword.operator"],
             "language_filter": "whitelist",
-            "language_list": ["HTML", "HTML 5", "XML", "PHP", "HTML+CFML", "ColdFusion", "ColdFusionCFC"],
+            "language_list": ["HTML", "HTML 5", "XML", "PHP", "CFML", "HTML+CFML", "ColdFusion", "ColdFusionCFC"],
             "plugin_library": "bh_modules.tags",
             "enabled": true
         },
@@ -707,7 +707,7 @@ Let's say you want to modify an existing rule, maybe just tweak the language lis
             "language_list": [
                 "HTML", "HTML 5", "XML", "PHP", "HTML (Rails)",
                 "HTML (Jinja Templates)", "HTML (Jinja2)", "HTML (Twig)",
-                "HTML+CFML", "ColdFusion", "ColdFusionCFC",
+                "CFML", "HTML+CFML", "ColdFusion", "ColdFusionCFC",
                 "laravel-blade", "Handlebars", "AngularJS",
                 "SomeNewLanguage" // <--- New language
             ]


### PR DESCRIPTION
Long time CFML user and was having issues with BracketHighlighter and the CFML plugin for Sublime (https://github.com/jcberquist/sublimetext-cfml)

Think the CFML syntax changed or was updated at some point but I was not getting any highlighting in .cfm/.cfc files. 

I went through the my local config files and everywhere there was "HTML+CFML" and added just "CFML" and this now seems to correctly flag CF tags, etc, while continuing to work for brackets, HTML, etc. 