### PR TITLE
Enhancement/sel to bracket

### DIFF
--- a/Example.sublime-keymap
+++ b/Example.sublime-keymap
@@ -47,6 +47,40 @@
             }
         }
     },
+    // Select to left bracket
+    {
+        "keys": ["ctrl+alt+shift+super+up"],
+        "command": "bh_key",
+        "args":
+        {
+            "no_outside_adj": null,
+            "no_block_mode": null,
+            "lines" : true,
+            "plugin":
+            {
+                "type": ["__all__"],
+                "command": "bh_modules.bracketselect",
+                "args": {"select": "left", "extend": true}
+            }
+        }
+    },
+    // Select to right bracket
+    {
+        "keys": ["ctrl+alt+shift+super+down"],
+        "command": "bh_key",
+        "args":
+        {
+            "no_outside_adj": null,
+            "no_block_mode": null,
+            "lines" : true,
+            "plugin":
+            {
+                "type": ["__all__"],
+                "command": "bh_modules.bracketselect",
+                "args": {"select": "right", "extend": true}
+            }
+        }
+    },
     // Remove brackets
     {
         "keys": ["ctrl+alt+super+r"],

--- a/bh_modules/bracketselect.py
+++ b/bh_modules/bracketselect.py
@@ -17,6 +17,10 @@ class SelectBracket(bh_plugin.BracketPluginCommand):
         """
         Select the content between brackets.
 
+        If "extend" is set to true, extend the current
+        selection up to (and including) the left/right bracket
+        when jumping to the left/right bracket.
+
         If "always_include_brackets" is enabled,
         include the brackets as well.
         If the content is already selected, expand to the parent.

--- a/bh_modules/bracketselect.py
+++ b/bh_modules/bracketselect.py
@@ -13,7 +13,7 @@ DEFAULT_TAGS = ["cfml", "html", "angle"]
 class SelectBracket(bh_plugin.BracketPluginCommand):
     """Select Bracket plugin."""
 
-    def run(self, edit, name, select='', extend=False, tags=None, always_include_brackets=False, alternate=False):
+    def run(self, edit, name, select='', tags=None, always_include_brackets=False, alternate=False, extend=False):
         """
         Select the content between brackets.
 

--- a/docs/src/markdown/usage.md
+++ b/docs/src/markdown/usage.md
@@ -69,7 +69,7 @@ BH is also extendable via plugins and provides a number of built-in Bracket Plug
 
 ### Bracket Select Plugin
 
-The Bracket Select plugin selects the content between the brackets or moves the selection to the opening or closing bracket.  Behavior is slightly modified for tags.  When the `extend` argument is set to `true`, the Bracket Select plugin extends the current selection to the left/right bracket when jumping to the choosen bracket.
+The Bracket Select plugin selects the content between the brackets or moves the selection to the opening or closing bracket.  Behavior is slightly modified for tags.  When the `extend` argument is set to `true`, the Bracket Select plugin extends the current selection to the left/right bracket when jumping to the chosen bracket.
 
 ### Swap Brackets Plugin
 

--- a/docs/src/markdown/usage.md
+++ b/docs/src/markdown/usage.md
@@ -69,7 +69,7 @@ BH is also extendable via plugins and provides a number of built-in Bracket Plug
 
 ### Bracket Select Plugin
 
-The Bracket Select plugin selects the content between the brackets or moves the selection to the opening or closing bracket.  Behavior is slightly modified for tags.
+The Bracket Select plugin selects the content between the brackets or moves the selection to the opening or closing bracket.  Behavior is slightly modified for tags.  When the `extend` argument is set to `true`, the Bracket Select plugin extends the current selection to the left/right bracket when jumping to the choosen bracket.
 
 ### Swap Brackets Plugin
 


### PR DESCRIPTION
This behavior attempts to fulfill the expectation a user might have if shift was held while jumping to the left or right bracket.

This change adds an additional argument to the Select Bracket plugin called 'extend' that allows a user to extend their current selection while jumping to a bracket via the `SelectBracket::select_left() `and `SelectBracket::select_right()` methods.

For instance, if your cursor was in the middle of some text between 2 brackets and the user invoked the Select Bracket plugin with arguments `"select"="right"` and `"extend"=true`, the right half of the text would be selected up, but not including, the right bracket.

This new behavior will mimic the current behavior of jumping to the parent brackets if continually calling the Select Bracket plugin with the same arguments.

Continuing with the previous example, if the Select Bracket plugin was called again with the same arguments, now the right half of the text would be selecting up to, and including the right bracket.  And if called again, all the text to the right of the cursor up to, but not including, the parent bracket would be selected.