### PR TITLE
Fixing Bash / ShellScript 'case' round bracket exclution

### DIFF
--- a/bh_core.sublime-settings
+++ b/bh_core.sublime-settings
@@ -368,7 +368,7 @@
                 "string",
                 "comment",
                 "source.regexp constant.character.escape",
-                "keyword.control.conditional.patterns.end.shell",
+                "keyword.control.case.item",
                 "source.yaml-tmlanguage constant.character.escape"
             ],
             "language_filter": "blocklist",


### PR DESCRIPTION
Reflecting the changes of Sublime Bash syntax highlighting difinitions related to the round bracket in case pattern on BH's exclusion definition. Fixing #567 