### PR TITLE
Use async callbacks where possible to prevent UI from hanging

### DIFF
--- a/bh_core.py
+++ b/bh_core.py
@@ -1013,7 +1013,7 @@ class BhListenerCommand(sublime_plugin.EventListener):
             elif region is not None:
                 bh_popup.BhOffscreenPopup().show_popup(view, point, region, icon)
 
-    def on_load(self, view):
+    def on_load_async(self, view):
         """Search brackets on view load."""
 
         if self.ignore_event(view):
@@ -1022,7 +1022,7 @@ class BhListenerCommand(sublime_plugin.EventListener):
         bh_thread.view = view
         sublime.set_timeout(bh_thread.payload, 0)
 
-    def on_modified(self, view):
+    def on_modified_async(self, view):
         """Update highlighted brackets when the text changes."""
 
         if self.ignore_event(view):
@@ -1050,7 +1050,7 @@ class BhListenerCommand(sublime_plugin.EventListener):
                 for region_key in view.settings().get("bracket_highlighter.regions", []):
                     view.erase_regions(region_key)
 
-    def on_activated(self, view):
+    def on_activated_async(self, view):
         """Highlight brackets when the view gains focus again."""
 
         if bh_thread is not None:
@@ -1062,7 +1062,7 @@ class BhListenerCommand(sublime_plugin.EventListener):
         bh_thread.view = view
         sublime.set_timeout(bh_thread.payload, 0)
 
-    def on_selection_modified(self, view):
+    def on_selection_modified_async(self, view):
         """Highlight brackets when the selections change."""
 
         if self.ignore_event(view):


### PR DESCRIPTION
This PR tries to address a problem with the blocking of the UI when moving the cursor(selection)

Even that brackets are highlighted in a separate thread there are some lags(the app is like waiting for something) when you move the cursor quickly(I'd say relatively quickly). 
For example, in my case, when I moved the cursor from the beginning of the line to the end of the line a few times it sometimes took a few seconds for the cursor to finish the command.
When I replaced normal callbacks with their async versions the blocking issue had gone

I can try to record a video to illustrate the problem.
Also, I disabled/enabled plugins to make sure it is BracketHighlighter causing the delay