### PR TITLE
Adopt changed Ruby on Rails syntax name

### DIFF
--- a/bh_core.sublime-settings
+++ b/bh_core.sublime-settings
@@ -503,7 +503,7 @@
             "scope_exclude": ["string", "comment"],
             "plugin_library": "bh_modules.rubykeywords",
             "language_filter": "allowlist",
-            "language_list": ["Ruby", "RSpec", "Better RSpec", "Ruby on Rails"],
+            "language_list": ["Ruby", "RSpec", "Better RSpec", "Ruby on Rails", "Ruby (Rails)"],
             "enabled": true
         },
         // C/C++ compile switches


### PR DESCRIPTION
Since the merge of https://github.com/sublimehq/Packages/pull/2797 the "Ruby on Rails" syntax is named "Ruby (Rails)".
This change aims to keep backward compatibility while supporting the new syntax name.

Cheers!