### PR TITLE
Add ColdFusion arrow function scope exclusion

### DIFF
--- a/bh_core.sublime-settings
+++ b/bh_core.sublime-settings
@@ -433,6 +433,7 @@
                 "keyword.operator",
                 "source.ruby.rails.embedded.html",
                 "source.ruby.embedded.html",
+                "storage.type.function.arrow.cfml",
                 "storage.type.function.arrow.js",
                 "punctuation.accessor.php",
                 "punctuation.accessor.arrow.php",


### PR DESCRIPTION
Fixes #618 

Add "storage.type.function.arrow.cfml" to angle scope_exclude list.

This allows BH to recognize arrow functions within ColdFusion code.

I don't think the documentation needs to be updated.