### PR TITLE
Drop obsolete dependencies

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -4,14 +4,8 @@
             "backrefs"
         ],
         ">=3124": [
-            "pygments",
-            "python-markdown",
-            "mdpopups",
-            "python-jinja2",
-            "markupsafe",
             "backrefs",
-            "pymdownx",
-            "pyyaml"
+            "mdpopups"
         ]
     }
 }

--- a/support.py
+++ b/support.py
@@ -100,19 +100,19 @@ class BracketHighlighterSupportInfoCommand(sublime_plugin.ApplicationCommand):
             info["backrefs_version"] = 'Version could not be acquired!'
 
         try:
-            import markdown
+            from mdpopups import markdown
             info["markdown_version"] = format_version(markdown, 'version')
         except Exception:
             info["markdown_version"] = 'Version could not be acquired!'
 
         try:
-            import jinja2
+            from mdpopups import jinja2
             info["jinja_version"] = format_version(jinja2, '__version__')
         except Exception:
             info["jinja_version"] = 'Version could not be acquired!'
 
         try:
-            import pygments
+            from mdpopups import pygments
             info["pygments_version"] = format_version(pygments, '__version__')
         except Exception:
             info["pygments_version"] = 'Version could not be acquired!'


### PR DESCRIPTION
This PR drops all dependencies but backrefs and mdpopups, which are the only really used ones since mdpopups vendors everything it needs.