### PR TITLE
Remove verbose parameter from namedtuple (fix for Python 3.8)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # BracketHighlighter
 
+## 2.32.1
+
+- **FIX**: Remove verbose parameter from named tubple which causes issues with Python 3.8.
+
 ## 2.32.0
 
 - **NEW**: Opt in to Python 3.8.

--- a/bh_modules/tags.py
+++ b/bh_modules/tags.py
@@ -26,7 +26,7 @@ def process_tag_pattern(pattern, variables=None):
     return pattern
 
 
-class TagEntry(namedtuple('TagEntry', ['begin', 'end', 'name', 'optional', 'single'], verbose=False)):
+class TagEntry(namedtuple('TagEntry', ['begin', 'end', 'name', 'optional', 'single'])):
     """Tag entry tuple."""
 
     def move(self, begin, end):

--- a/support.py
+++ b/support.py
@@ -5,7 +5,7 @@ import textwrap
 import webbrowser
 import re
 
-__version__ = "2.32.0"
+__version__ = "2.32.1"
 __pc_name__ = 'BracketHighlighter'
 
 CSS = '''


### PR DESCRIPTION
Fixes #640
