### PR TITLE
Fix py313 compatibility (ST 4201)

### DIFF
--- a/bh_plugin.py
+++ b/bh_plugin.py
@@ -7,7 +7,6 @@ License: MIT
 import sublime
 import sublime_plugin
 from os.path import normpath, join
-import imp
 from collections import namedtuple
 import sys
 import traceback
@@ -83,6 +82,17 @@ def load_modules(obj, loaded):
         raise
 
 
+def new_module(name):
+    """Create a new module."""
+
+    if sys.version_info < (3, 4):
+        import imp
+        return imp.new_module(name)
+
+    import types
+    return types.ModuleType(name)
+
+
 def _import_module(module_name, loaded=None):
     """
     Import the module.
@@ -100,7 +110,7 @@ def _import_module(module_name, loaded=None):
     if loaded is not None and module_name in loaded:
         module = sys.modules[module_name]
     else:
-        module = imp.new_module(module_name)
+        module = new_module(module_name)
         sys.modules[module_name] = module
         exec(
             compile(


### PR DESCRIPTION
The latest ST 4201, which replaces py38 with py313, has been released as a private beta in the discord. See [discord.com/channels/280102180189634562/650695903446827011/1432613579223339059](https://discord.com/channels/280102180189634562/650695903446827011/1432613579223339059)

## Issue

`imp.new_module` is deprecated as of py34 and no longer exists in py313 (not sure the exact version it got removed in).